### PR TITLE
fix build on ubuntu 15.04

### DIFF
--- a/globals/config.h
+++ b/globals/config.h
@@ -14,6 +14,7 @@
 #define CONFIG_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 
 #define VERSION_MAJOR 1
@@ -78,8 +79,8 @@ typedef __int64 Sint64;
 typedef __int64 Uint64;
 
 #else
-typedef signed long long Sint64;
-typedef unsigned long long Uint64;
+typedef int64_t Sint64;
+typedef uint64_t Uint64;
 
 #endif
 


### PR DESCRIPTION
Fix the ubuntu build problem in https://github.com/reduz/chibitracker/issues/1

The header files in libsdl1.2-dev seem to have an incompatible definition of Sint64 and Uint64.